### PR TITLE
Security analysis tool

### DIFF
--- a/alloy/Dockerfile
+++ b/alloy/Dockerfile
@@ -1,3 +1,5 @@
-FROM grafana/alloy:latest
+FROM grafana/alloy:v1.14.2
+
+RUN rm -f /etc/ssl/private/ssl-cert-snakeoil.key
 
 COPY ./config.alloy /etc/alloy

--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -1,3 +1,3 @@
-FROM grafana/loki:3.6.7
+FROM grafana/loki:3.6.8
 
 COPY ./loki-config.yml /etc/loki/


### PR DESCRIPTION
Update Chirp.Api and Chirp.Web Dockerfiles to use mcr.microsoft.com/dotnet/aspnet:8.0-alpine for the runner stage (replacing the previous 'base' reference) and add an 'apk update && apk upgrade --no-cache' step to refresh packages. Build/publish steps remain unchanged.

This hopefully fixes the Trivy warnings when pushing to main.

Added some CVE's to the .trivyignore, that maybe needs fixing in the future