### PR TITLE
Security analysis tool

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -11,3 +11,9 @@ CVE-2026-25679
 
 # Go stdlib crypto/x509 email constraints - Prometheus v3.10.0 built with Go 1.26.0, fix requires 1.26.1
 CVE-2026-27137
+
+# buger/jsonparser DoS - Prometheus v3.10.0 ships v1.1.1, fix requires 1.1.2. No stable release with fix yet
+GHSA-6g7g-w4f8-9c9x
+
+# Moby AuthZ plugin bypass - Prometheus v3.10.0 ships docker v28.5.2, fix requires 29.3.1. No stable release with fix yet
+CVE-2026-34040


### PR DESCRIPTION
Update Chirp.Api and Chirp.Web Dockerfiles to use mcr.microsoft.com/dotnet/aspnet:8.0-alpine for the runner stage (replacing the previous 'base' reference) and add an 'apk update && apk upgrade --no-cache' step to refresh packages. Build/publish steps remain unchanged.

This hopefully fixes the Trivy warnings when pushing to main.

Added some CVE's to the .trivyignore, that maybe needs fixing in the future