### PR TITLE
Security analysis tool

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -17,3 +17,6 @@ GHSA-6g7g-w4f8-9c9x
 
 # Moby AuthZ plugin bypass - Prometheus v3.10.0 ships docker v28.5.2, fix requires 29.3.1. No stable release with fix yet
 CVE-2026-34040
+
+# antchfx/xpath infinite loop - Alloy v1.14.2 ships v1.3.5, fix requires 1.3.6. No stable Alloy release with fix yet
+CVE-2026-32287


### PR DESCRIPTION
Update Chirp.Api and Chirp.Web Dockerfiles to use mcr.microsoft.com/dotnet/aspnet:8.0-alpine for the runner stage (replacing the previous 'base' reference) and add an 'apk update && apk upgrade --no-cache' step to refresh packages. Build/publish steps remain unchanged.

This hopefully fixes the Trivy warnings when pushing to main.

Added some CVE's to the .trivyignore, that maybe needs fixing in the future