### PR TITLE
fix: case-insensitive search, account deletion refactor, and auth key permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,14 @@ services:
         max-size: "10m"      
         max-file: "3"
     
+  keys-init:
+    image: busybox
+    command: ["sh", "-c", "chown -R 1654:1654 /app/keys"]
+    volumes:
+      - dataprotection_keys:/app/keys
+    networks:
+      - internal
+
   api:
     image: cecilieelkjaer/minitwit-api:latest
     build:
@@ -38,8 +46,10 @@ services:
     ports:
       - "5000:8080"
     depends_on:
-      postgres: 
+      postgres:
         condition: service_healthy
+      keys-init:
+        condition: service_completed_successfully
     networks:
       - internal
     logging:
@@ -63,8 +73,10 @@ services:
     ports:
       - "5001:8080"
     depends_on:
-      postgres: 
+      postgres:
         condition: service_healthy
+      keys-init:
+        condition: service_completed_successfully
     networks:
       - internal
     labels:

--- a/src/Chirp.Api/Dockerfile
+++ b/src/Chirp.Api/Dockerfile
@@ -18,6 +18,8 @@ RUN apk update && apk upgrade --no-cache
 WORKDIR /app
 COPY --from=build /app/publish .
 
+RUN mkdir -p /app/keys && chown -R $APP_UID /app/keys
+
 USER $APP_UID
 
 ENTRYPOINT ["dotnet", "Chirp.Api.dll"]

--- a/src/Chirp.Infrastructure/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/AuthorRepository.cs
@@ -270,7 +270,7 @@ namespace Chirp.Infrastructure
             {
                 // Perform a case-insensitive search for authors whose name contains the search word
                 return await this.dbContext.Authors
-                    .Where(a => EF.Functions.ILike(a.Name!, $"%{searchWord}%"))
+                    .Where(a => EF.Functions.Like(a.Name, $"%{searchWord}%"))
                     .Select(a => new AuthorDTO
                     {
                         Name = a.Name, // Map Author entity to AuthorDTO
@@ -280,7 +280,7 @@ namespace Chirp.Infrastructure
             else
             {
                 return await this.dbContext.Authors
-                    .Where(a => EF.Functions.ILike(a.Name!, $"{searchWord}%"))
+                    .Where(a => EF.Functions.Like(a.Name, $"{searchWord}%"))
                     .Select(a => new AuthorDTO
                     {
                         Name = a.Name, // Map Author entity to AuthorDTO

--- a/src/Chirp.Infrastructure/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/AuthorRepository.cs
@@ -270,7 +270,7 @@ namespace Chirp.Infrastructure
             {
                 // Perform a case-insensitive search for authors whose name contains the search word
                 return await this.dbContext.Authors
-                    .Where(a => EF.Functions.Like(a.Name, $"%{searchWord}%"))
+                    .Where(a => EF.Functions.ILike(a.Name!, $"%{searchWord}%"))
                     .Select(a => new AuthorDTO
                     {
                         Name = a.Name, // Map Author entity to AuthorDTO
@@ -280,7 +280,7 @@ namespace Chirp.Infrastructure
             else
             {
                 return await this.dbContext.Authors
-                    .Where(a => EF.Functions.Like(a.Name, $"{searchWord}%"))
+                    .Where(a => EF.Functions.ILike(a.Name!, $"{searchWord}%"))
                     .Select(a => new AuthorDTO
                     {
                         Name = a.Name, // Map Author entity to AuthorDTO
@@ -316,11 +316,49 @@ namespace Chirp.Infrastructure
         /// Deletes an author/user from the database.
         /// </summary>
         /// <param name="author">The author to delete.</param>
-        /// <returns>True if the operation succeeded.</returns>
+        /// <returns>True if the author was found and deleted; otherwise, false.</returns>
         public async Task<bool> DeleteAuthor(Author author)
         {
-            IdentityResult result = await this.userManager.DeleteAsync(author);
-            return result.Succeeded;
+            var authorEntry = await this.dbContext.Authors
+                .Include(a => a.Cheeps)
+                .Include(a => a.Followers)
+                .Include(a => a.FollowedAuthors)
+                .AsSplitQuery()
+                .FirstOrDefaultAsync(a => a.Id == author.Id);
+
+            if (authorEntry == null)
+            {
+                return false;
+            }
+
+            // Remove cheeps
+            var cheepsToDelete = authorEntry.Cheeps?.ToList() ?? new List<Cheep>();
+            foreach (var cheep in cheepsToDelete)
+            {
+                this.dbContext.Cheeps.Remove(cheep);
+            }
+
+            // Clear follower relationships (authors who follow this author)
+            if (authorEntry.Followers != null)
+            {
+                foreach (var follower in authorEntry.Followers.ToList())
+                {
+                    authorEntry.Followers.Remove(follower);
+                }
+            }
+
+            // Clear followed relationships (authors this author follows)
+            if (authorEntry.FollowedAuthors != null)
+            {
+                foreach (var followed in authorEntry.FollowedAuthors.ToList())
+                {
+                    authorEntry.FollowedAuthors.Remove(followed);
+                }
+            }
+
+            this.dbContext.Authors.Remove(authorEntry);
+            await this.dbContext.SaveChangesAsync();
+            return true;
         }
     }
 }

--- a/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.10" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">

--- a/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
+++ b/src/Chirp.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
@@ -2,16 +2,12 @@
 
 #nullable disable
 
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Threading.Tasks;
 using Chirp.Core;
 using Chirp.Infrastructure;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
 {
@@ -19,18 +15,15 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
     {
         private readonly UserManager<Author> userManager;
         private readonly SignInManager<Author> signInManager;
-        private readonly CheepDBContext context;
         private readonly IAuthorRepository authorRepository;
 
         public DeletePersonalDataModel(
             UserManager<Author> userManager,
             SignInManager<Author> signInManager,
-            CheepDBContext context,
             IAuthorRepository authorRepository)
         {
             this.userManager = userManager;
             this.signInManager = signInManager;
-            this.context = context;
             this.authorRepository = authorRepository;
         }
 
@@ -82,45 +75,7 @@ namespace Chirp.Web.Areas.Identity.Pages.Account.Manage
 
             if (author != null)
             {
-                // Reload the author from the DbContext with relational collections to manipulate navigation properties
-                var authorEntry = await this.context.Authors
-                    .Include(a => a.Cheeps)
-                    .Include(a => a.Followers)
-                    .Include(a => a.FollowedAuthors)
-                    .AsSplitQuery()
-                    .FirstOrDefaultAsync(a => a.Id == author.Id);
-
-                if (authorEntry != null)
-                {
-                    // Remove cheeps
-                    var cheepsToDelete = authorEntry.Cheeps?.ToList() ?? new System.Collections.Generic.List<Chirp.Core.Cheep>();
-                    foreach (var cheep in cheepsToDelete)
-                    {
-                        this.context.Cheeps.Remove(cheep);
-                    }
-
-                    // Clear follower relationships (authors who follow this author)
-                    if (authorEntry.Followers != null)
-                    {
-                        foreach (var follower in authorEntry.Followers.ToList())
-                        {
-                            authorEntry.Followers.Remove(follower);
-                        }
-                    }
-
-                    // Clear followed relationships (authors this author follows)
-                    if (authorEntry.FollowedAuthors != null)
-                    {
-                        foreach (var followed in authorEntry.FollowedAuthors.ToList())
-                        {
-                            authorEntry.FollowedAuthors.Remove(followed);
-                        }
-                    }
-
-                    // Now safe to remove the author
-                    this.context.Authors.Remove(authorEntry);
-                    await this.context.SaveChangesAsync();
-                }
+                await this.authorRepository.DeleteAuthor(author);
             }
 
             await this.signInManager.SignOutAsync();

--- a/src/Chirp.Web/Dockerfile
+++ b/src/Chirp.Web/Dockerfile
@@ -18,6 +18,8 @@ RUN apk update && apk upgrade --no-cache
 WORKDIR /app
 COPY --from=build /app/publish .
 
+RUN mkdir -p /app/keys && chown -R $APP_UID /app/keys
+
 USER $APP_UID
 
 ENTRYPOINT ["dotnet", "Chirp.Web.dll"]


### PR DESCRIPTION
- Replace EF.Functions.Like with ILike in SearchAuthorsAsync for case-insensitive author search (PostgreSQL ILIKE); add Npgsql.EntityFrameworkCore.PostgreSQL to Chirp.Infrastructure.csproj so ILike compiles correctly
- Extract account deletion logic (cheeps, followers, following relationships) from DeletePersonalData.cshtml.cs into AuthorRepository.DeleteAuthor; remove direct DbContext dependency from the page model
- Fix data protection key permissions: add RUN mkdir -p /app/keys && chown -R $APP_UID /app/keys to Chirp.Web and Chirp.Api Dockerfiles; add keys-init busybox service to docker-compose.yml that chowns the shared volume to UID/GID 1654 before api and web start (condition: service_completed_successfully)